### PR TITLE
[FE-16] feat: Icon 컴포넌트 png 지원확장

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     ]
   },
   "devDependencies": {
+    "@types/webpack-env": "^1.18.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
     "eslint": "^8.43.0",

--- a/src/components/shared/Icon/index.tsx
+++ b/src/components/shared/Icon/index.tsx
@@ -8,7 +8,19 @@ interface Props extends ImgHTMLAttributes<HTMLImageElement> {
 }
 
 function Icon({ className, name, alt, ...restProps }: Props) {
-	const imagePath = `assets/${name}.svg`;
+	const svgImagePath = `/assets/${name}.svg`;
+	const pngImagePath = `/assets/${name}.png`;
+
+	const svgImageExists = require
+		.context('/public/assets', false, /\.svg$/)
+		.keys()
+		.includes(`./${name}.svg`);
+	const pngImageExists = require
+		.context('/public/assets', false, /\.png$/)
+		.keys()
+		.includes(`./${name}.png`);
+
+	const imagePath = svgImageExists ? svgImagePath : pngImageExists ? pngImagePath : '';
 
 	return <Image className={className} src={imagePath} alt={alt ?? name} {...restProps} />;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,6 +2592,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/webpack-env@^1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.1.tgz#49699bb508961e14a3bfb68c78cd87b296889d1d"
+  integrity sha512-D0HJET2/UY6k9L6y3f5BL+IDxZmPkYmPT4+qBrRdmRLYRuV0qNKizMgTvYxXZYn+36zjPeoDZAEYBCM6XB+gww==
+
 "@types/ws@^8.5.5":
   version "8.5.5"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz#af587964aa06682702ee6dcbc7be41a80e4b28eb"


### PR DESCRIPTION
### Ticket
[티켓](https://foodiezone.atlassian.net/browse/FE-16?atlOrigin=eyJpIjoiZjRmMDk5M2U5NTVhNGU4MzhkMTUyMmJjZTkyY2RlN2IiLCJwIjoiaiJ9)

### Purpose
Icon 컴포넌트의 고도화, svg만을 사용할 수 있었던 적은 범위의 지원을 png까지 지원하도록 확장한다.

### Description
Icon 컴포넌트에서 svg, png파일이 public/assets에 위치해있는지 검사하고 svg를 우선순위를 둔상태로 둘중 하나라도 파일이 있는경우 로드할 수 있도록 한다.

### How to test
testImage.png를 넣고 Icon name에 testImage를 입력했을때 정상적으로 로드됨을 확인.
.svg로 작성됐던 기존의 이미지들도 정상 노출됨을 확인.

### Additional Info
N/A

### Screen Shots & Video
N/A
